### PR TITLE
Add missing tide icons for git, rustc, python, terraform and fix pwd icon

### DIFF
--- a/modules/fish/files/.config/fish/conf.d/10-fish-core.fish
+++ b/modules/fish/files/.config/fish/conf.d/10-fish-core.fish
@@ -23,14 +23,58 @@ if status --is-interactive
     abbr du "du -kh"
 
     # --- Prompt (Tide) ---
-    set -g tide_left_prompt_items pwd git newline status character
-    set -g tide_right_prompt_items cmd_duration jobs direnv node python rustc go terraform
-    set -g tide_git_truncation_length 32
+    # Use -U with guards to work with tide's universal variable model
+    # Only writes when the value doesn't match, so no unnecessary writes per shell launch
+    test "$tide_left_prompt_items" != "pwd git newline status character"; and set -U tide_left_prompt_items pwd git newline status character
+    test "$tide_right_prompt_items" != "cmd_duration jobs direnv node python rustc go terraform"; and set -U tide_right_prompt_items cmd_duration jobs direnv node python rustc go terraform
+    test "$tide_git_truncation_length" != 32; and set -U tide_git_truncation_length 32
+
+    # --- Colors (match p10k lean-8colors) ---
+    # Character
+    test "$tide_character_color" != green; and set -U tide_character_color green
+    test "$tide_character_color_failure" != red; and set -U tide_character_color_failure red
+    # Git
+    test "$tide_git_color_branch" != green; and set -U tide_git_color_branch green
+    test "$tide_git_color_conflicted" != red; and set -U tide_git_color_conflicted red
+    test "$tide_git_color_dirty" != yellow; and set -U tide_git_color_dirty yellow
+    test "$tide_git_color_operation" != red; and set -U tide_git_color_operation red
+    test "$tide_git_color_staged" != yellow; and set -U tide_git_color_staged yellow
+    test "$tide_git_color_stash" != green; and set -U tide_git_color_stash green
+    test "$tide_git_color_untracked" != green; and set -U tide_git_color_untracked green
+    test "$tide_git_color_upstream" != green; and set -U tide_git_color_upstream green
+    # Status
+    test "$tide_status_color" != green; and set -U tide_status_color green
+    test "$tide_status_color_failure" != red; and set -U tide_status_color_failure red
+    # PWD (keep tide defaults)
+    test "$tide_pwd_color_anchors" != 00AFFF; and set -U tide_pwd_color_anchors 00AFFF
+    test "$tide_pwd_color_dirs" != 0087AF; and set -U tide_pwd_color_dirs 0087AF
+    test "$tide_pwd_color_truncated_dirs" != 8787AF; and set -U tide_pwd_color_truncated_dirs 8787AF
+    # Cmd Duration
+    test "$tide_cmd_duration_color" != yellow; and set -U tide_cmd_duration_color yellow
+    # Jobs
+    test "$tide_jobs_color" != red; and set -U tide_jobs_color red
+    # Direnv
+    test "$tide_direnv_color" != yellow; and set -U tide_direnv_color yellow
+    test "$tide_direnv_color_denied" != red; and set -U tide_direnv_color_denied red
+    # Node
+    test "$tide_node_color" != green; and set -U tide_node_color green
+    # Python
+    test "$tide_python_color" != cyan; and set -U tide_python_color cyan
+    # Rustc
+    test "$tide_rustc_color" != blue; and set -U tide_rustc_color blue
+    # Go
+    test "$tide_go_color" != cyan; and set -U tide_go_color cyan
+    # Terraform
+    test "$tide_terraform_color" != blue; and set -U tide_terraform_color blue
 
     # --- Icons (match p10k nerdfont-complete) ---
-    set -g tide_pwd_icon \uf115
-    set -g tide_node_icon \ue617
-    set -g tide_go_icon \ue626
-    set -g tide_cmd_duration_icon \uf252
-    set -g tide_jobs_icon \uf013
+    test "$tide_pwd_icon" != \uf07b; and set -U tide_pwd_icon \uf07b
+    test "$tide_git_icon" != \uf126; and set -U tide_git_icon \uf126
+    test "$tide_node_icon" != \ue617; and set -U tide_node_icon \ue617
+    test "$tide_go_icon" != \ue626; and set -U tide_go_icon \ue626
+    test "$tide_cmd_duration_icon" != \uf252; and set -U tide_cmd_duration_icon \uf252
+    test "$tide_jobs_icon" != \uf013; and set -U tide_jobs_icon \uf013
+    test "$tide_rustc_icon" != \ue7a8; and set -U tide_rustc_icon \ue7a8
+    test "$tide_python_icon" != \ue73c; and set -U tide_python_icon \ue73c
+    test "$tide_terraform_icon" != \U000F1062; and set -U tide_terraform_icon \U000F1062
 end


### PR DESCRIPTION
Use guarded universal variables for tide prompt, colors, and icons

Switch from `set -g` to `set -U` with guards so tide config persists
correctly as universal variables. Add p10k lean-8colors color scheme
for all segments (keeping tide's default PWD colors).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
