### PR TITLE
Prefer BBEdit for EDITOR/VISUAL with vim/vi fallback

### DIFF
--- a/modules/editor/files/.config/fish/conf.d/50-editor-abbrs.fish
+++ b/modules/editor/files/.config/fish/conf.d/50-editor-abbrs.fish
@@ -1,4 +1,14 @@
-# editor module - program launcher abbreviations
+# editor module - EDITOR/VISUAL exports and program launcher abbreviations
+
+# prefer BBEdit on macOS, fall back to vim then vi
+if type -q bbedit
+    set -gx EDITOR bbedit -w
+    set -gx VISUAL bbedit -w
+else if type -q vim
+    set -gx EDITOR vim
+else
+    set -gx EDITOR vi
+end
 
 if status --is-interactive
     abbr -a ia 'open -a "iA Writer"'

--- a/modules/editor/files/.zsh/conf.d/50-editor-env-aliases.sh
+++ b/modules/editor/files/.zsh/conf.d/50-editor-env-aliases.sh
@@ -1,16 +1,14 @@
 # shellcheck shell=zsh
 # editor module - EDITOR/VISUAL exports and editor aliases
 
-# use vim if possible, otherwise vi
-if hash vim 2>/dev/null; then
+# prefer BBEdit on macOS, fall back to vim then vi
+if hash bbedit 2>/dev/null; then
+  export EDITOR='bbedit -w'
+  export VISUAL='bbedit -w'
+elif hash vim 2>/dev/null; then
   export EDITOR=vim
 else
   export EDITOR=vi
-fi
-
-# use Nova, if possible
-if hash nova 2>/dev/null; then
-	export VISUAL=nova
 fi
 
 alias e='${(z)VISUAL:-${(z)EDITOR}}'


### PR DESCRIPTION
## Summary
- Sets `EDITOR` and `VISUAL` to `bbedit -w` on macOS in both zsh and fish, falling back to vim then vi
- Adds the EDITOR export to fish (previously had none — fish was relying on inheritance)
- Replaces the old Nova `VISUAL` binding

Git's `core.editor` was already on `bbedit -w --resume --new-window`, so no change there.

## Test plan
- [ ] Open a new zsh shell, confirm `echo $EDITOR` prints `bbedit -w`
- [ ] Open a new fish shell, confirm `echo $EDITOR` prints `bbedit -w`
- [ ] Run `git commit` on a test repo and confirm BBEdit opens, blocks, and the commit lands when the window closes
- [ ] On a machine without BBEdit installed, confirm fallback to `vim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)