### PR TITLE
Add cd dot-expansion for up-N navigation in fish and zsh

### DIFF
--- a/modules/fish/files/.config/fish/conf.d/10-fish-core.fish
+++ b/modules/fish/files/.config/fish/conf.d/10-fish-core.fish
@@ -15,7 +15,7 @@ set -gx LS_COLORS 'rs=0:di=00;38;5;39:ex=00;32:ln=00;38;5;5:'
 if status --is-interactive
     # --- Abbreviations ---
     abbr dot "cd $DOTFILES"
-    abbr dotdot --regex '^\.\.+$' --function multicd
+    abbr dotdot --position anywhere --regex '^\.\.\.+$' --function multidot
     abbr ip "dig +short myip.opendns.com @resolver1.opendns.com"
     abbr pubkey "cat ~/.ssh/*.pub | pbcopy; echo '=> Public key copied to clipboard.'"
     abbr mkdir "mkdir -p"

--- a/modules/fish/files/.config/fish/functions/multicd.fish
+++ b/modules/fish/files/.config/fish/functions/multicd.fish
@@ -1,5 +1,0 @@
-# fish module - navigate up multiple directories with repeated dots
-# Go up multiple directories
-function multicd
-    echo cd (string repeat -n (math (string length -- $argv[1]) - 1) ../)
-end

--- a/modules/fish/files/.config/fish/functions/multidot.fish
+++ b/modules/fish/files/.config/fish/functions/multidot.fish
@@ -1,0 +1,6 @@
+# fish module - expand repeated dots into a chain of ../
+# `...` -> ../.. (up 2), `....` -> ../../.. (up 3), etc.
+# Used as an `--position anywhere` abbreviation so `cd ...` works.
+function multidot
+    string repeat -n (math (string length -- $argv[1]) - 1) ../
+end

--- a/modules/zsh/files/.zsh/conf.d/10-zsh-core.sh
+++ b/modules/zsh/files/.zsh/conf.d/10-zsh-core.sh
@@ -207,3 +207,6 @@ rationalise-dot() {
 }
 zle -N rationalise-dot
 bindkey . rationalise-dot
+# Keep "." literal inside incremental search (Ctrl-R); without this the
+# main-keymap rebind above makes "." abort the search instead of extending it.
+bindkey -M isearch . self-insert


### PR DESCRIPTION
Type `cd ...` to go up two directories, `cd ....` for three, and so on for any depth — with `cd` muscle memory intact, on both shells.

## fish
- Switch the repeated-dot abbreviation to `--position anywhere` so it expands as a `../` chain **argument** (`cd ...` → `cd ../../`) instead of only prepending `cd` in command position. Now requires 3+ dots, leaving `..` fully native.
- Rename helper `multicd` → `multidot` (emits just the path, no `cd`).

## zsh
- The `rationalise-dot` ZLE widget already provided this. Add `bindkey -M isearch . self-insert` so `.` stays literal inside Ctrl-R incremental search rather than aborting the search (a side effect of rebinding `.` in the main keymap).

## Notes
- New files aren't auto-stowed; `multidot.fish` was symlinked into place locally and will link on next deploy for other machines.
- Minor known caveat (zsh only): a filename with 3+ consecutive dots typed on the command line gets mangled (`foo...` → `foo../..`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)